### PR TITLE
Use environment variables for credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+MYSQL_ROOT_PASSWORD=changeme
+MYSQL_DATABASE=mastershop_db
+
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/mastershop_db?characterEncoding=UTF-8&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=root
+SPRING_DATASOURCE_PASSWORD=${MYSQL_ROOT_PASSWORD}
+SPRING_REDIS_HOST=redis
+SPRING_REDIS_PORT=6379
+
+PAYPAL_CLIENT_ID=your_paypal_client_id
+PAYPAL_CLIENT_SECRET=your_paypal_client_secret

--- a/LavenShopBackend/src/main/java/com/dong/contants/PaypalConstants.java
+++ b/LavenShopBackend/src/main/java/com/dong/contants/PaypalConstants.java
@@ -1,8 +1,26 @@
 package com.dong.contants;
 
-public interface PaypalConstants {
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
-    String BASE_URI = "https://api-m.sandbox.paypal.com";
-    String CLIENT_ID  = "ASViZj3VChGkol3QG1RfeBT1R11y1wies-IXaBtVSdKWu9vc5mU1tzBxWQuSkkrsvX9gRb4FI9ZXWTR3";
-    String CLENT_SECRET = "EJsVisLY654yUhiqBJdxsK-p92HMA6Q-lXhRqEk2sAVugXDSBSO8S7KtVjjS3-V47vfsk-8PvJynbhKp";
+@Component
+public class PaypalConstants {
+
+    public static final String BASE_URI = "https://api-m.sandbox.paypal.com";
+
+    public static String CLIENT_ID;
+    public static String CLENT_SECRET;
+
+    @Value("${PAYPAL_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${PAYPAL_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @PostConstruct
+    public void init() {
+        CLIENT_ID = clientId;
+        CLENT_SECRET = clientSecret;
+    }
 }

--- a/LavenShopBackend/src/main/resources/application.properties
+++ b/LavenShopBackend/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=MasterShopBackend
-spring.datasource.url=jdbc:mysql://deploymaster-mysql-1:3306/mastershop_db?characterEncoding=UTF-8&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=dong
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
-redis.host=redis
-redis.port=6379
+redis.host=${SPRING_REDIS_HOST}
+redis.port=${SPRING_REDIS_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/mastershop_db
-      SPRING_DATASOURCE_USERNAME: root
-      SPRING_DATASOURCE_PASSWORD: dong
-      SPRING_REDIS_HOST: redis
-      SPRING_REDIS_PORT: 6379
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_REDIS_HOST: ${SPRING_REDIS_HOST}
+      SPRING_REDIS_PORT: ${SPRING_REDIS_PORT}
+      PAYPAL_CLIENT_ID: ${PAYPAL_CLIENT_ID}
+      PAYPAL_CLIENT_SECRET: ${PAYPAL_CLIENT_SECRET}
     depends_on:
       mysql:
         condition: service_healthy
@@ -29,8 +31,8 @@ services:
   mysql:
     image: mysql:8
     environment:
-      MYSQL_ROOT_PASSWORD: dong
-      MYSQL_DATABASE: mastershop_db
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
       - "3307:3306"
     volumes:


### PR DESCRIPTION
## Summary
- load PayPal credentials from environment variables
- fetch database and Redis settings from env
- switch docker-compose to use env vars and provide `.env.example`

## Testing
- `mvn test` *(fails: could not download Maven dependencies)*