### PR TITLE
Add stack README and clarify frontend commands

### DIFF
--- a/LavenFontend/README.md
+++ b/LavenFontend/README.md
@@ -1,4 +1,4 @@
-cd# LavenShop
+# LavenShop
 Link to Backend repo: [Laven BE](https://github.com/huynhduydong/MasterShop)
 ## Introduction
 ### Project: Laven - E-commerce Platform
@@ -50,13 +50,18 @@ Some of the pictures of this Application
    ```
 2. Navigate to the project directory:
    ```
-   cd LavenShop
+   cd lavenshop
    ```
 3. Install dependencies:
    ```
    npm install
    ```
-4. Build the project:
+4. Start the project in development mode:
    ```
    npm run dev
+   ```
+   For a production build use:
+   ```
+   npm run build
+   npm start
    ```

--- a/LavenFontend/lavenshop/README.md
+++ b/LavenFontend/lavenshop/README.md
@@ -50,13 +50,18 @@ Some of the pictures of this Application
    ```
 2. Navigate to the project directory:
    ```
-   cd LavenShop
+   cd lavenshop
    ```
 3. Install dependencies:
    ```
    npm install
    ```
-4. Build the project:
+4. Start the project in development mode:
    ```
    npm run dev
+   ```
+   For a production build use:
+   ```
+   npm run build
+   npm start
    ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# DeployMaster
+
+DeployMaster contains everything needed to run the Laven e‑commerce sample.
+It includes a Spring Boot backend, a Next.js frontend, database scripts and a
+Jenkins pipeline.  Docker Compose can be used to orchestrate the entire stack.
+
+## Repository layout
+
+- **LavenShopBackend/** – Spring Boot API service
+- **LavenFontend/lavenshop/** – Next.js frontend application
+- **database/** – MySQL initialization scripts
+- **docker-compose.yml** – compose file bringing up the services
+- **Jenkinsfile** – CI pipeline building and starting the stack
+
+## Running the stack
+
+Ensure Docker and Docker Compose are installed. From the repository root run:
+
+```bash
+docker-compose up --build
+```
+
+The services will be built and started:
+
+- Backend available on [http://localhost:8080](http://localhost:8080)
+- Frontend available on [http://localhost:3000](http://localhost:3000)
+- Jenkins UI on [http://localhost:8081](http://localhost:8081)
+
+MySQL is exposed on port `3307` and Redis on `6379`.
+
+## Development
+
+You can also run the services individually during development.
+
+### Backend
+
+```bash
+cd LavenShopBackend
+./mvnw spring-boot:run
+```
+
+### Frontend
+
+```bash
+cd LavenFontend/lavenshop
+npm install
+npm run dev
+```
+
+For a production build of the frontend use:
+
+```bash
+npm run build
+npm start
+```


### PR DESCRIPTION
## Summary
- document repository layout and docker-compose usage
- clarify frontend setup steps

## Testing
- `npm run lint` *(fails: next not found)*
- `sh ./mvnw -q test` *(fails: failed to fetch maven)*